### PR TITLE
Update of the friend trees producer and update of the plotting scripts 

### DIFF
--- a/TTHAnalysis/python/plotter/vbfH-diphoton/mca-vbfhgg.txt
+++ b/TTHAnalysis/python/plotter/vbfH-diphoton/mca-vbfhgg.txt
@@ -20,11 +20,11 @@ VBFL1   : output_VBFHiggs0L1ToGG_M125* : 0.001; FillColor=ROOT.kMagenta  , Label
 
 VBFL1f05   : output_VBFHiggs0L1f05ph0ToGG_M125* : 0.001; FillColor=ROOT.kGreen+2  , Label="VBF H\#rightarrow\#gamma\#gamma (f_{\#Lambda1} = 0.5)", NormSystematic=0.1, TreeName="vbfTagDumper/trees/vbf_125_13TeV_GeneralDipho"
 
-VBFfa3f1   : output_VBFHiggs0MToGG_M125* : 0.001; FillColor=ROOT.kBlue  , Label="VBF H\#rightarrow\#gamma\#gamma (f_{a3} = 1.0)", NormSystematic=0.1, TreeName="vbfTagDumper/trees/vbf_125_13TeV_GeneralDipho"
+VBFfa3   : output_VBFHiggs0MToGG_M125* : 0.001; FillColor=ROOT.kBlue  , Label="VBF H\#rightarrow\#gamma\#gamma (f_{a3} = 1.0)", NormSystematic=0.1, TreeName="vbfTagDumper/trees/vbf_125_13TeV_GeneralDipho"
 
 VBFfa3f05   : output_VBFHiggs0Mf05ph0ToGG_M125* : 0.001; FillColor=ROOT.kAzure+1  , Label="VBF H\#rightarrow\#gamma\#gamma (f_{a3} = 0.5)", NormSystematic=0.1, TreeName="vbfTagDumper/trees/vbf_125_13TeV_GeneralDipho"
 
-VBFfa2f1   : output_VBFHiggs0PHToGG_M125* : 0.001; FillColor=ROOT.kOrange+1  , Label="VBF H\#rightarrow\#gamma\#gamma (f_{a2} = 1.0)", NormSystematic=0.1, TreeName="vbfTagDumper/trees/vbf_125_13TeV_GeneralDipho"
+VBFfa2   : output_VBFHiggs0PHToGG_M125* : 0.001; FillColor=ROOT.kOrange+1  , Label="VBF H\#rightarrow\#gamma\#gamma (f_{a2} = 1.0)", NormSystematic=0.1, TreeName="vbfTagDumper/trees/vbf_125_13TeV_GeneralDipho"
 
 VBFfa2f05   : output_VBFHiggs0PHf05ph0ToGG_M125* : 0.001; FillColor=ROOT.kBlack, Label="VBF H\#rightarrow\#gamma\#gamma (f_{a2} = 0.5)", NormSystematic=0.1, TreeName="vbfTagDumper/trees/vbf_125_13TeV_GeneralDipho"
 

--- a/TTHAnalysis/python/plotter/vbfH-diphoton/vbfhgg.txt
+++ b/TTHAnalysis/python/plotter/vbfH-diphoton/vbfhgg.txt
@@ -6,5 +6,5 @@ dipho_MVA : dipho_leadIDMVA > -0.2 && dipho_subleadIDMVA > -0.2
 dijet_eta : dijet_abs_dEta > 0.0 && fabs(dijet_leadEta) < 4.7 && fabs(dijet_subleadEta) < 4.7 && dijet_minDRJetPho > 0.4
 dijet_pt : dijet_LeadJPt > 40. && dijet_SubJPt > 30.
 dijet_Mjj : dijet_Mjj > 250.0
-tight_dijet_Mjj : dijet_Mjj > 350
+#tight_dijet_Mjj : dijet_Mjj > 350
 tight_dipho_MVA : dipho_leadIDMVA > 0.5 && dipho_subleadIDMVA > 0.5

--- a/TTHAnalysis/python/plotter/vbfH-diphoton/vbfhgg_plots.txt
+++ b/TTHAnalysis/python/plotter/vbfH-diphoton/vbfhgg_plots.txt
@@ -84,3 +84,18 @@ dijet_mva_prob_ggH : dijet_mva_prob_ggH: 50,0,1.0; XTitle="ggH probability (VBF 
 
 dijet_mva_prob_bkg : dijet_mva_prob_bkg: 50,0,1.0; XTitle="Bkg probability (VBF MVA)", Legend='TC', IncludeOverflows=True, Logy=True
 
+D0minus : D0minus: 50,0,1.0; XTitle="D_{0-}", Legend='TC', IncludeOverflows=True, Logy=False
+
+D0hplus : D0hplus: 50,0,1.0; XTitle="D_{0h+}", Legend='TC', IncludeOverflows=True, Logy=False
+
+DCP : DCP: 50,-1,1.0; XTitle="D_{CP}", Legend='TC', IncludeOverflows=True, Logy=False
+
+Dint : Dint: 50,-1,1.0; XTitle="D_{int}", Legend='TC', IncludeOverflows=True, Logy=False
+
+D0minus_za : D0minus_za: 50,0,1.0; XTitle="D_{0-}^{Z#gamma}", Legend='TC', IncludeOverflows=True, Logy=False
+
+D0hplus_za : D0hplus_za: 50,0,1.0; XTitle="D_{0h+}^{Z#gamma}", Legend='TC', IncludeOverflows=True, Logy=False
+
+DCP_za : DCP_za: 50,-1,1.0; XTitle="D_{CP}^{Z#gamma}", Legend='TC', IncludeOverflows=True, Logy=False
+
+Dint_za : Dint_za: 50,-1,1.0; XTitle="D_{int}^{Z#gamma}", Legend='TC', IncludeOverflows=True, Logy=False


### PR DESCRIPTION
* friend trees: bug fix for the main submission (the names of the output trees are not yet correct, **TO BE FIXED** in a later PR)
* plot script config files now use also the MELA variables computed in the friend trees. See for example here:
https://emanuele.web.cern.ch/Analysis/HtoGG/vbfac/selection/2021-12-02-vbfPresel-signalsShapesOnly/

the command is:
`python mcPlots.py -f -l 41.5 --s2v vbfH-diphoton/mca-vbfhgg.txt vbfH-diphoton/vbfhgg.txt vbfH-diphoton/vbfhgg_plots.txt --noCms -P trees/VBFHiggs_UL2017_27September2021/ -F "Friends" "{P}/friends/{cname}_Friend.root" -W weight --pdir plots/2021-12-02-vbfPresel-signalsShapesOnly --xp ".*10x,data,DiPhoton,GJets" --legendFontSize 0.03 --allProcInLegend --n-column-legend 2 --setLegendCoordinates 0.2,0.72,0.95,0.92 --noLegendRatioPlot --showRatio --maxRatioRange 0.5 1.5 --fixRatioRange --ratioNums VBFfa3,VBFfa3f05,VBFL1Zgf05,VBFfa2,VBFfa2f05,VBFL1,VBFL1f05 --ratioDen VBFpow --ratioYLabel X/powheg --contentAxisTitle Arbitrary units --forceFillColorNostackMode VBFpow --no-heppy-tree -j8 --plotmode norm`
